### PR TITLE
Remove unnecessary use of platform

### DIFF
--- a/faculty_sync/screens/diff.py
+++ b/faculty_sync/screens/diff.py
@@ -53,23 +53,23 @@ Keys:
 
 
 UP_SYNC_HELP_TEXT = """\
-Press [u] to modify the Faculty Platform workspace so that it mirrors your local disk.
+Press [u] to modify the Faculty workspace so that it mirrors your local disk.
 
 This will make the following changes to your Faculty Platform workspace:
 """
 
 DOWN_SYNC_HELP_TEXT = """\
-Press [d] to modify your local filesystem so that it mirrors the Faculty Platform workspace.
+Press [d] to modify your local filesystem so that it mirrors the Faculty workspace.
 
 This will make the following changes to your local disk:
 """
 
 WATCH_HELP_TEXT = """\
-Press [w] to enter `watch` mode. Any time you save, move or delete a file, the change is automatically replicated on Faculty Platform.
+Press [w] to enter `watch` mode. Any time you save, move or delete a file, the change is automatically replicated on Faculty.
 """
 
 FULLY_SYNCHRONIZED_HELP_TEXT = """\
-Your local disk and the Faculty Platform workspace are fully synchronized.
+Your local disk and the Faculty workspace are fully synchronized.
 """
 
 

--- a/faculty_sync/screens/watch_sync.py
+++ b/faculty_sync/screens/watch_sync.py
@@ -50,7 +50,7 @@ class Loading(object):
         self._start_updating_loading_indicator()
 
     def _render(self):
-        self._control.text = "  {} Loading directory structure on Faculty Platform".format(
+        self._control.text = "  {} Loading directory structure on Faculty".format(
             self._loading_indicator.current()
         )
 
@@ -207,7 +207,7 @@ class HeldFiles(object):
                 Window(
                     FormattedTextControl(
                         "  The following files will not be synced to "
-                        "avoid accidentally overwriting changes on Faculty Platform:"
+                        "avoid accidentally overwriting changes on Faculty:"
                     ),
                     dont_extend_height=True,
                 ),
@@ -236,7 +236,7 @@ class WatchSyncScreen(BaseScreen):
         self.menu_bar = Window(
             FormattedTextControl(
                 "[s] Stop  "
-                "[d] Sync Faculty Platform files down  "
+                "[d] Sync files down  "
                 "[q] Quit  "
                 "[?] Help"
             ),

--- a/faculty_sync/screens/watch_sync.py
+++ b/faculty_sync/screens/watch_sync.py
@@ -235,10 +235,7 @@ class WatchSyncScreen(BaseScreen):
 
         self.menu_bar = Window(
             FormattedTextControl(
-                "[s] Stop  "
-                "[d] Sync files down  "
-                "[q] Quit  "
-                "[?] Help"
+                "[s] Stop  [d] Sync files down  [q] Quit  [?] Help"
             ),
             height=1,
             style="reverse",


### PR DESCRIPTION
The brand guidelines suggest that the words 'Faculty Platform' should
only be used if there's ambiguity about what part of Faculty we are
referring to. In general, we are supposed to prefer 'Faculty'.